### PR TITLE
fix UIView animation.

### DIFF
--- a/ScrollingFollowView/ScrollingFollowView.swift
+++ b/ScrollingFollowView/ScrollingFollowView.swift
@@ -70,17 +70,14 @@ extension ScrollingFollowView {
         superview?.layoutIfNeeded()
         
         if animated {
-            constraint.constant = minFollowPoint
-            
-            CATransaction.begin()
-            CATransaction.setCompletionBlock(completionHandler)
-            
-            UIView.animateWithDuration(duration) { [weak self] in
-                guard let `self` = self else { return }
-                self.superview?.layoutIfNeeded()
-            }
-            
-            CATransaction.commit()
+            UIView.animateWithDuration(duration,
+                                       animations: { [weak self] in
+                                        guard let `self` = self else { return }
+                                        self.constraint.constant = self.minFollowPoint
+                                        self.superview?.layoutIfNeeded() },
+                                       completion: { _ in
+                                        completionHandler?()
+            })
         } else {
             constraint.constant = minFollowPoint
             superview?.layoutIfNeeded()
@@ -92,17 +89,14 @@ extension ScrollingFollowView {
         superview?.layoutIfNeeded()
         
         if animated {
-            constraint.constant = maxFollowPoint
-            
-            CATransaction.begin()
-            CATransaction.setCompletionBlock(completionHandler)
-            
-            UIView.animateWithDuration(duration) { [weak self] in
-                guard let `self` = self else { return }
-                self.superview?.layoutIfNeeded()
-            }
-            
-            CATransaction.commit()
+            UIView.animateWithDuration(duration,
+                                       animations: { [weak self] in
+                                        guard let `self` = self else { return }
+                                        self.constraint.constant = self.maxFollowPoint
+                                        self.superview?.layoutIfNeeded() },
+                                       completion: { _ in
+                                        completionHandler?()
+            })
         } else {
             constraint.constant = maxFollowPoint
             superview?.layoutIfNeeded()


### PR DESCRIPTION
・CATransactionは CALayerをアニメーションさせたい時に使用するので、中でUIView.animateWithDurationを呼んでいるなら、不要だと思いました。
